### PR TITLE
bug: regenerate network config when port is added and on startup

### DIFF
--- a/openstack_port_provider/cmd/main.py
+++ b/openstack_port_provider/cmd/main.py
@@ -250,22 +250,20 @@ def main(
 
             os_conn.compute.create_server_interface(os_server.id, port_id=os_port.id)
 
-            os_actual_ports.append(os_port)
-
             # wait for port become active
             if wait_for_port:
                 logger.debug(f"Waiting for port {os_port_name}")
                 _wait_for_port(os_conn, os_port_name)
 
-        # create networking config for each port
-        networking_config_handler.create(
-            os_ports=os_actual_ports,
-            os_subnets=os_expected_subnets,
-            config_destination=networking_config_destination,
-            config_templates=networking_config_templates,
-        )
+            # create networking config for the port
+            networking_config_handler.create(
+                os_port=os_port,
+                os_subnet=os_missing_subnet,
+                config_destination=networking_config_destination,
+                config_templates=networking_config_templates,
+            )
 
-        # apply networking config
+        # apply networking config if necessary
         networking_config_handler.apply()
 
         logger.debug(f"Wait for {reconciliation_interval}s until reconciliation.")

--- a/openstack_port_provider/cmd/main.py
+++ b/openstack_port_provider/cmd/main.py
@@ -216,7 +216,12 @@ def main(
 
         # find out what subnets are missing on the server
         os_expected_subnet_ids = set(os_expected_subnets.keys())
-        os_missing_subnet_ids = set(os_expected_subnet_ids) - set(os_actual_subnet_ids)
+
+        # on "boot" we declare all are missing
+        if networking_config_handler.should_apply:
+            os_missing_subnet_ids = os_expected_subnet_ids
+        else:
+            os_missing_subnet_ids = os_expected_subnet_ids - set(os_actual_subnet_ids)
 
         logger.debug(
             msg=(
@@ -248,7 +253,8 @@ def main(
             if port_tags:
                 os_conn.network.set_tags(os_port, port_tags)
 
-            os_conn.compute.create_server_interface(os_server.id, port_id=os_port.id)
+            if not os_port.device_id:
+                os_conn.compute.create_server_interface(os_server.id, port_id=os_port.id)
 
             # wait for port become active
             if wait_for_port:

--- a/openstack_port_provider/networking/__init__.py
+++ b/openstack_port_provider/networking/__init__.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+from .base import BaseNetworkingConfigHandler
 from .netplan import NetplanNetworkingConfigHandler
 
 
@@ -7,7 +8,7 @@ class NetworkingConfigType(str, Enum):
     netplan = "netplan"
 
 
-def get_networking_config_handler(config_type: NetworkingConfigType, **kwargs):
+def get_networking_config_handler(config_type: NetworkingConfigType, **kwargs) -> BaseNetworkingConfigHandler:
     if config_type == NetworkingConfigType.netplan:
         if "apply_cmd" in kwargs:
             return NetplanNetworkingConfigHandler(apply_cmd=kwargs['apply_cmd'])

--- a/openstack_port_provider/networking/base/__init__.py
+++ b/openstack_port_provider/networking/base/__init__.py
@@ -4,11 +4,14 @@ from typing import Any
 
 
 class BaseNetworkingConfigHandler(metaclass=ABCMeta):
+    def __init__(self, should_apply: bool = True) -> None:
+        self.should_apply = should_apply
+
     @abstractmethod
     def create(
         self,
-        os_ports: Any,
-        os_subnets: Any,
+        os_port: Any,
+        os_subnet: Any,
         config_destination: Path,
         config_templates: Path,
     ) -> None:
@@ -17,3 +20,11 @@ class BaseNetworkingConfigHandler(metaclass=ABCMeta):
     @abstractmethod
     def apply(self) -> None:
         raise NotImplementedError
+
+    @property
+    def should_apply(self) -> bool:
+        return self._should_apply
+
+    @should_apply.setter
+    def should_apply(self, value: bool):
+        self._should_apply = value

--- a/openstack_port_provider/networking/netplan/__init__.py
+++ b/openstack_port_provider/networking/netplan/__init__.py
@@ -16,8 +16,6 @@ class NetplanNetworkingConfigHandler(BaseNetworkingConfigHandler):
         super().__init__()
         self.logger = logging.getLogger(__name__)
         self.apply_cmd = apply_cmd
-        # Note(sprietl): Assume (for simplicity) that on startup the network config has to be applied.
-        self.should_apply = True
 
     def create(
         self,


### PR DESCRIPTION
TODO:

- [x] Does not fix the case when an already wrong config is generated (all ports attached)